### PR TITLE
Improve handling of slurm_user partitions

### DIFF
--- a/lib/puppet/provider/sacctmgr.rb
+++ b/lib/puppet/provider/sacctmgr.rb
@@ -326,6 +326,11 @@ class Puppet::Provider::Sacctmgr < Puppet::Provider
       when 'user'
         cmd << "account=#{@resource[:account]}"
         cmd << "cluster=#{@resource[:cluster]}"
+        cmd << if @resource[:partition].to_s != 'absent'
+                 "partition=#{@resource[:partition]}"
+               else
+                 'partition='
+               end
       when 'resource'
         cmd << "server=#{@resource[:server]}"
         cmd << "cluster=#{@resource[:cluster]}" if @resource[:cluster]

--- a/lib/puppet/provider/slurm_user/sacctmgr.rb
+++ b/lib/puppet/provider/slurm_user/sacctmgr.rb
@@ -93,7 +93,7 @@ Puppet::Type.type(:slurm_user).provide(:sacctmgr, parent: Puppet::Provider::Sacc
   end
 
   def destroy
-    if @resource[:user] == 'root'
+    if @resource[:user] == 'root' and @resource[:partition] == :absent
       Puppet.warning("Slurm_user[#{@resource[:name]}] Not permitted to delete root user. Must define root user or remove cluster")
       return
     end

--- a/lib/puppet/provider/slurm_user/sacctmgr.rb
+++ b/lib/puppet/provider/slurm_user/sacctmgr.rb
@@ -49,7 +49,11 @@ Puppet::Type.type(:slurm_user).provide(:sacctmgr, parent: Puppet::Provider::Sacc
         Puppet.debug("slurm_user instances: value=#{value} class=#{value.class}")
         user[property] = value
       end
-      user[:name] = "#{user[:user]} under #{user[:account]} on #{user[:cluster]}"
+      user[:name] = if user[:partition] != :absent
+                      "#{user[:user]} under #{user[:account]} on #{user[:cluster]} partition #{user[:partition]}"
+                    else
+                      "#{user[:user]} under #{user[:account]} on #{user[:cluster]}"
+                    end
       users << new(user)
     end
     users

--- a/lib/puppet/provider/slurm_user/sacctmgr.rb
+++ b/lib/puppet/provider/slurm_user/sacctmgr.rb
@@ -93,7 +93,7 @@ Puppet::Type.type(:slurm_user).provide(:sacctmgr, parent: Puppet::Provider::Sacc
   end
 
   def destroy
-    if @resource[:user] == 'root' and @resource[:partition] == :absent
+    if (@resource[:user] == 'root') && (@resource[:partition] == :absent)
       Puppet.warning("Slurm_user[#{@resource[:name]}] Not permitted to delete root user. Must define root user or remove cluster")
       return
     end

--- a/spec/fixtures/unit/puppet/provider/slurm_user/sacctmgr/list.out
+++ b/spec/fixtures/unit/puppet/provider/slurm_user/sacctmgr/list.out
@@ -1,3 +1,4 @@
-root|root|linux|Administrator|root||1||||||||||||||||normal
-root|root|test|Administrator|root||1||||||||||||||||normal
-testuser|test2|test|None|test2||1||||||||10||||||||normal
+root|root|linux||Administrator|root||1||||||||||||||||normal
+root|root|test||Administrator|root||1||||||||||||||||normal
+testuser|test2|test||None|test2||1||||||||10||||||||normal
+testuser|test2|test|testpart|None|test2||1||||||||10||||||||normal

--- a/spec/unit/puppet/provider/slurm_user/sacctmgr_spec.rb
+++ b/spec/unit/puppet/provider/slurm_user/sacctmgr_spec.rb
@@ -155,5 +155,20 @@ describe Puppet::Type.type(:slurm_user).provider(:sacctmgr) do
         expect(property_hash).to eq({})
       end
     end
+
+    context 'when the user is root' do
+      it 'will warn and not delete without a partition' do
+        resource[:user] = 'root'
+        expect(Puppet).to receive(:warning).with('Slurm_user[foo under test on linux] Not permitted to delete root user. Must define root user or remove cluster')
+        resource.provider.destroy
+      end
+
+      it 'deletes from the partition' do
+        resource[:user] = 'root'
+        resource[:partition] = 'testpart'
+        expect(resource.provider).to receive(:sacctmgr).with(['-i', 'delete', 'user', 'where', 'name=root', 'account=test', 'cluster=linux', 'partition=testpart'])
+        resource.provider.destroy
+      end
+    end
   end
 end

--- a/spec/unit/puppet/provider/slurm_user/sacctmgr_spec.rb
+++ b/spec/unit/puppet/provider/slurm_user/sacctmgr_spec.rb
@@ -84,7 +84,7 @@ describe Puppet::Type.type(:slurm_user).provider(:sacctmgr) do
     it 'creates instances' do
       allow(described_class).to receive(:sacctmgr) \
         .with(['list', 'user', "format=#{format_string}", '--noheader', '--parsable2', 'withassoc']).and_return(my_fixture_read('list.out'))
-      expect(described_class.instances.length).to eq(3)
+      expect(described_class.instances.length).to eq(4)
     end
 
     it 'creates instance with name' do
@@ -92,6 +92,13 @@ describe Puppet::Type.type(:slurm_user).provider(:sacctmgr) do
         .with(['list', 'user', "format=#{format_string}", '--noheader', '--parsable2', 'withassoc']).and_return(my_fixture_read('list.out'))
       property_hash = described_class.instances[0].instance_variable_get('@property_hash')
       expect(property_hash[:name]).to eq('root under root on linux')
+    end
+
+    it 'creates instance with name and partition' do
+      allow(described_class).to receive(:sacctmgr) \
+        .with(['list', 'user', "format=#{format_string}", '--noheader', '--parsable2', 'withassoc']).and_return(my_fixture_read('list.out'))
+      property_hash = described_class.instances[3].instance_variable_get('@property_hash')
+      expect(property_hash[:name]).to eq('testuser under test2 on test partition testpart')
     end
   end
 
@@ -106,7 +113,7 @@ describe Puppet::Type.type(:slurm_user).provider(:sacctmgr) do
 
   describe 'flush' do
     it 'updates a qos' do
-      expect(resource.provider).to receive(:sacctmgr).with(['-i', 'modify', 'user', 'where', 'name=foo', 'account=test', 'cluster=linux', 'set', 'grptres=cpu=1'])
+      expect(resource.provider).to receive(:sacctmgr).with(['-i', 'modify', 'user', 'where', 'name=foo', 'account=test', 'cluster=linux', 'partition=', 'set', 'grptres=cpu=1'])
       resource.provider.grp_tres = { 'cpu' => 1 }
       resource.provider.flush
     end

--- a/spec/unit/puppet/provider/slurm_user/sacctmgr_spec.rb
+++ b/spec/unit/puppet/provider/slurm_user/sacctmgr_spec.rb
@@ -103,28 +103,57 @@ describe Puppet::Type.type(:slurm_user).provider(:sacctmgr) do
   end
 
   describe 'create' do
-    it 'creates a qos' do
+    it 'creates a user' do
       expect(resource.provider).to receive(:sacctmgr).with(['-i', 'create', 'user', 'foo', 'account=test', 'cluster=linux', 'adminlevel=None', 'fairshare=1'])
       resource.provider.create
       property_hash = resource.provider.instance_variable_get('@property_hash')
       expect(property_hash[:ensure]).to eq(:present)
     end
+
+    context 'with a partition' do
+      it 'creates a user' do
+        resource[:partition] = 'testpart'
+        expect(resource.provider).to receive(:sacctmgr).with(['-i', 'create', 'user', 'foo', 'account=test', 'cluster=linux', 'partition=testpart', 'adminlevel=None', 'fairshare=1'])
+        resource.provider.create
+        property_hash = resource.provider.instance_variable_get('@property_hash')
+        expect(property_hash[:ensure]).to eq(:present)
+      end
+    end
   end
 
   describe 'flush' do
-    it 'updates a qos' do
+    it 'updates a user' do
       expect(resource.provider).to receive(:sacctmgr).with(['-i', 'modify', 'user', 'where', 'name=foo', 'account=test', 'cluster=linux', 'partition=', 'set', 'grptres=cpu=1'])
       resource.provider.grp_tres = { 'cpu' => 1 }
       resource.provider.flush
     end
+
+    context 'with a partition' do
+      it 'updates a user' do
+        resource[:partition] = 'testpart'
+        expect(resource.provider).to receive(:sacctmgr).with(['-i', 'modify', 'user', 'where', 'name=foo', 'account=test', 'cluster=linux', 'partition=testpart', 'set', 'grptres=cpu=1'])
+        resource.provider.grp_tres = { 'cpu' => 1 }
+        resource.provider.flush
+      end
+    end
   end
 
   describe 'destroy' do
-    it 'delets a qos' do
+    it 'deletes a user' do
       expect(resource.provider).to receive(:sacctmgr).with(['-i', 'delete', 'user', 'where', 'name=foo', 'account=test', 'cluster=linux'])
       resource.provider.destroy
       property_hash = resource.provider.instance_variable_get('@property_hash')
       expect(property_hash).to eq({})
+    end
+
+    context 'with a partition' do
+      it 'deletes a user' do
+        resource[:partition] = 'testpart'
+        expect(resource.provider).to receive(:sacctmgr).with(['-i', 'delete', 'user', 'where', 'name=foo', 'account=test', 'cluster=linux', 'partition=testpart'])
+        resource.provider.destroy
+        property_hash = resource.provider.instance_variable_get('@property_hash')
+        expect(property_hash).to eq({})
+      end
     end
   end
 end


### PR DESCRIPTION
Correctly prefetch instances of slurm_user with a partition set, constructing the correct resource title including the partition name. Add test case to validate parsing happens correctly.

Correctly filter updates to match the partition when flushing changes to prevent unwanted changes to unmatched instances. Update tests to ensure empty partition filter is applied when not used.

Fixes fixtures to add partition fields.

Fixes #38 