### PR TITLE
Add support for Account Coordinators

### DIFF
--- a/lib/puppet/provider/sacctmgr.rb
+++ b/lib/puppet/provider/sacctmgr.rb
@@ -260,7 +260,7 @@ class Puppet::Provider::Sacctmgr < Puppet::Provider
   def set_values(create) # rubocop:disable Style/AccessorMethodName
     result = []
     properties = if create
-                   type_params - [self.class.name_attribute] + type_properties - self.property_skip_create_values
+                   type_params - [self.class.name_attribute] + type_properties - property_skip_create_values
                  else
                    @property_flush.keys
                  end
@@ -324,6 +324,7 @@ class Puppet::Provider::Sacctmgr < Puppet::Provider
     @property_hash[:ensure] = :present
     property_skip_create_values.each do |p|
       next if @resource[p] == :absent
+
       send("create_#{p}")
     end
   end

--- a/lib/puppet/provider/slurm_account/sacctmgr.rb
+++ b/lib/puppet/provider/slurm_account/sacctmgr.rb
@@ -34,7 +34,7 @@ Puppet::Type.type(:slurm_account).provide(:sacctmgr, parent: Puppet::Provider::S
 
   def self.instances
     accounts = []
-    sacctmgr_list(true, 'user' => '').each_line do |line|
+    sacctmgr_list(true, false, 'user' => '').each_line do |line|
       Puppet.debug("slurm_account instances: LINE=#{line}")
       values = line.chomp.split('|')
       account = {}

--- a/lib/puppet/provider/slurm_license/sacctmgr.rb
+++ b/lib/puppet/provider/slurm_license/sacctmgr.rb
@@ -34,7 +34,7 @@ Puppet::Type.type(:slurm_license).provide(:sacctmgr, parent: Puppet::Provider::S
 
   def self.instances
     licenses = []
-    sacctmgr_list(false, {}, ['withclusters']).each_line do |line|
+    sacctmgr_list(false, false, {}, ['withclusters']).each_line do |line|
       Puppet.debug("slurm_license instances: LINE=#{line}")
       values = line.chomp.split('|')
       license = {}

--- a/lib/puppet/provider/slurm_user/sacctmgr.rb
+++ b/lib/puppet/provider/slurm_user/sacctmgr.rb
@@ -53,15 +53,13 @@ Puppet::Type.type(:slurm_user).provide(:sacctmgr, parent: Puppet::Provider::Sacc
 
         # Override Coordinator list into boolean depending on whether (previously-set) account is in the list
         if property == :coordinator
-          if value == :absent
-            value = :false
-          else
-            value = if value.include?(user[:account])
-                      :true
-                    else
-                      :false
-                    end
-          end
+          value = if value == :absent
+                    :false
+                  elsif value.include?(user[:account])
+                    :true
+                  else
+                    :false
+                  end
         end
 
         Puppet.debug("slurm_user instances: value=#{value} class=#{value.class}")
@@ -113,12 +111,12 @@ Puppet::Type.type(:slurm_user).provide(:sacctmgr, parent: Puppet::Provider::Sacc
   def set_coordinator
     value = @property_flush[:coordinator]
 
-    return if value.nil? or value == :absent
+    return if value.nil? || (value == :absent)
 
     action = if value == :true
                'add'
              else
-                'remove'
+               'remove'
              end
 
     Puppet.notice("Setting SLURM coordinator=#{value} for user=#{resource[:user]} account=#{resource[:account]}")

--- a/lib/puppet/type/slurm_user.rb
+++ b/lib/puppet/type/slurm_user.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'puppet/property/boolean'
 require_relative '../../puppet_x/slurm/type'
 require_relative '../../puppet_x/slurm/array_property'
 require_relative '../../puppet_x/slurm/float_property'
@@ -67,6 +68,15 @@ Puppet type that manages a SLURM user
     newvalues('None', 'Operator', 'Administrator')
     defaultto('None')
     munge { |v| v.to_s }
+  end
+
+  newproperty(:coordinator, :boolean => true, :parent => Puppet::Property::Boolean) do
+    desc 'Coordinators'
+    newvalue(:true)
+    newvalue(:false)
+    defaultto(:false)
+    # Undo default munging into symbols
+    munge { |v| if v == true then :true else :false end }
   end
 
   newproperty(:default_account) do
@@ -234,6 +244,9 @@ Puppet type that manages a SLURM user
     end
     if self[:account].nil?
       raise "Slurm_user[#{self[:name]}] must have account defined"
+    end
+    if self[:partition].nil? and self[:coordinator] != :absent
+      raise "Slurm_user[#{self[:name]}] cannot manage coordinator when partition defined"
     end
   end
 end

--- a/lib/puppet/type/slurm_user.rb
+++ b/lib/puppet/type/slurm_user.rb
@@ -70,13 +70,13 @@ Puppet type that manages a SLURM user
     munge { |v| v.to_s }
   end
 
-  newproperty(:coordinator, :boolean => true, :parent => Puppet::Property::Boolean) do
+  newproperty(:coordinator, boolean: true, parent: Puppet::Property::Boolean) do
     desc 'Coordinators'
     newvalue(:true)
     newvalue(:false)
     defaultto(:false)
     # Undo default munging into symbols
-    munge { |v| if v == true then :true else :false end }
+    munge { |v| (v == true) ? :true : :false }
   end
 
   newproperty(:default_account) do
@@ -245,7 +245,7 @@ Puppet type that manages a SLURM user
     if self[:account].nil?
       raise "Slurm_user[#{self[:name]}] must have account defined"
     end
-    if self[:partition].nil? and self[:coordinator] != :absent
+    if self[:partition].nil? && (self[:coordinator] != :absent)
       raise "Slurm_user[#{self[:name]}] cannot manage coordinator when partition defined"
     end
   end

--- a/spec/fixtures/unit/puppet/provider/slurm_user/sacctmgr/list.out
+++ b/spec/fixtures/unit/puppet/provider/slurm_user/sacctmgr/list.out
@@ -1,4 +1,7 @@
-root|root|linux||Administrator|root||1||||||||||||||||normal
-root|root|test||Administrator|root||1||||||||||||||||normal
-testuser|test2|test||None|test2||1||||||||10||||||||normal
-testuser|test2|test|testpart|None|test2||1||||||||10||||||||normal
+root|root|linux||Administrator||root||1||||||||||||||||normal
+root|root|test||Administrator||root||1||||||||||||||||normal
+testuser|test2|test||None||test2||1||||||||10||||||||normal
+testuser|test2|test|testpart|None||test2||1||||||||10||||||||normal
+testcoord|test2|test||None|test2|test2||1||||||||10||||||||normal
+testcoord2|test2|test||None|test2|test2,test3||1||||||||10||||||||normal
+testcoord2|test3|test||None|test3|test2,test3||1||||||||10||||||||normal

--- a/spec/unit/puppet/provider/slurm_user/sacctmgr_spec.rb
+++ b/spec/unit/puppet/provider/slurm_user/sacctmgr_spec.rb
@@ -8,7 +8,7 @@ describe Puppet::Type.type(:slurm_user).provider(:sacctmgr) do
     :user, :account, :cluster, :partition,
   ]
   type_properties = [
-    :admin_level, :default_account, :default_qos, :fairshare, :grp_jobs, :grp_jobs_accrue, :grp_submit_jobs,
+    :admin_level, :coordinator, :default_account, :default_qos, :fairshare, :grp_jobs, :grp_jobs_accrue, :grp_submit_jobs,
     :grp_tres, :grp_tres_mins, :grp_tres_run_mins,
     :grp_wall, :max_jobs, :max_jobs_accrue, :max_submit_jobs, :max_tres_mins_per_job, :max_tres_per_job, :max_tres_per_node,
     :max_wall_duration_per_job, :priority, :qos,
@@ -57,7 +57,7 @@ describe Puppet::Type.type(:slurm_user).provider(:sacctmgr) do
     let(:grp_tres) { 'cpu=1' }
 
     it do
-      expect(value).to eq('foo|test|linux|||None|||1||||cpu=1||||||||||||')
+      expect(value).to eq('foo|test|linux|||None||||1||||cpu=1||||||||||||')
     end
   end
 
@@ -83,22 +83,43 @@ describe Puppet::Type.type(:slurm_user).provider(:sacctmgr) do
   describe 'self.instances' do
     it 'creates instances' do
       allow(described_class).to receive(:sacctmgr) \
-        .with(['list', 'user', "format=#{format_string}", '--noheader', '--parsable2', 'withassoc']).and_return(my_fixture_read('list.out'))
-      expect(described_class.instances.length).to eq(4)
+        .with(['list', 'user', "format=#{format_string}", '--noheader', '--parsable2', 'withassoc', 'withcoord']).and_return(my_fixture_read('list.out'))
+      expect(described_class.instances.length).to eq(7)
     end
 
     it 'creates instance with name' do
       allow(described_class).to receive(:sacctmgr) \
-        .with(['list', 'user', "format=#{format_string}", '--noheader', '--parsable2', 'withassoc']).and_return(my_fixture_read('list.out'))
+        .with(['list', 'user', "format=#{format_string}", '--noheader', '--parsable2', 'withassoc', 'withcoord']).and_return(my_fixture_read('list.out'))
       property_hash = described_class.instances[0].instance_variable_get('@property_hash')
       expect(property_hash[:name]).to eq('root under root on linux')
     end
 
     it 'creates instance with name and partition' do
       allow(described_class).to receive(:sacctmgr) \
-        .with(['list', 'user', "format=#{format_string}", '--noheader', '--parsable2', 'withassoc']).and_return(my_fixture_read('list.out'))
+        .with(['list', 'user', "format=#{format_string}", '--noheader', '--parsable2', 'withassoc', 'withcoord']).and_return(my_fixture_read('list.out'))
       property_hash = described_class.instances[3].instance_variable_get('@property_hash')
       expect(property_hash[:name]).to eq('testuser under test2 on test partition testpart')
+    end
+
+    it 'creates instance without coordinator role' do
+      allow(described_class).to receive(:sacctmgr) \
+        .with(['list', 'user', "format=#{format_string}", '--noheader', '--parsable2', 'withassoc', 'withcoord']).and_return(my_fixture_read('list.out'))
+      property_hash = described_class.instances[3].instance_variable_get('@property_hash')
+      expect(property_hash[:coordinator]).to eq(:false)
+    end
+
+    it 'creates instance with coordinator role' do
+      allow(described_class).to receive(:sacctmgr) \
+        .with(['list', 'user', "format=#{format_string}", '--noheader', '--parsable2', 'withassoc', 'withcoord']).and_return(my_fixture_read('list.out'))
+      property_hash = described_class.instances[4].instance_variable_get('@property_hash')
+      expect(property_hash[:coordinator]).to eq(:true)
+    end
+    
+    it 'creates instance with multiple coordinator roles' do
+      allow(described_class).to receive(:sacctmgr) \
+        .with(['list', 'user', "format=#{format_string}", '--noheader', '--parsable2', 'withassoc', 'withcoord']).and_return(my_fixture_read('list.out'))
+      expect(described_class.instances[5].instance_variable_get('@property_hash')[:coordinator]).to eq(:true)
+      expect(described_class.instances[6].instance_variable_get('@property_hash')[:coordinator]).to eq(:true)
     end
   end
 
@@ -123,17 +144,57 @@ describe Puppet::Type.type(:slurm_user).provider(:sacctmgr) do
 
   describe 'flush' do
     it 'updates a user' do
-      expect(resource.provider).to receive(:sacctmgr).with(['-i', 'modify', 'user', 'where', 'name=foo', 'account=test', 'cluster=linux', 'partition=', 'set', 'grptres=cpu=1'])
+      expect(resource.provider).to receive(:sacctmgr).once.ordered.with(['-i', 'modify', 'user', 'where', 'name=foo', 'account=test', 'cluster=linux', 'partition=', 'set', 'grptres=cpu=1'])
       resource.provider.grp_tres = { 'cpu' => 1 }
       resource.provider.flush
+    end
+
+    context 'with coordinator role' do
+      it 'updates a user to add coordinator role' do
+        expect(resource.provider).to receive(:sacctmgr).once.ordered.with(['-i', 'modify', 'user', 'where', 'name=foo', 'account=test', 'cluster=linux', 'partition=', 'set', 'grptres=cpu=1'])
+        expect(resource.provider).to receive(:sacctmgr).once.ordered.with(['-i', 'add', 'coordinator', 'account=test', 'user=foo'])
+        resource.provider.grp_tres = { 'cpu' => 1 }
+        resource.provider.coordinator = :true
+        resource.provider.flush
+      end
+      
+      it 'updates a user to remove coordinator role' do
+        resource[:coordinator] = :true
+        expect(resource.provider).to receive(:sacctmgr).once.ordered.with(['-i', 'modify', 'user', 'where', 'name=foo', 'account=test', 'cluster=linux', 'partition=', 'set', 'grptres=cpu=1'])
+        expect(resource.provider).to receive(:sacctmgr).once.ordered.with(['-i', 'remove', 'coordinator', 'account=test', 'user=foo'])
+        resource.provider.grp_tres = { 'cpu' => 1 }
+        resource.provider.coordinator = :false
+        resource.provider.flush
+      end
     end
 
     context 'with a partition' do
       it 'updates a user' do
         resource[:partition] = 'testpart'
-        expect(resource.provider).to receive(:sacctmgr).with(['-i', 'modify', 'user', 'where', 'name=foo', 'account=test', 'cluster=linux', 'partition=testpart', 'set', 'grptres=cpu=1'])
+        expect(resource.provider).to receive(:sacctmgr).once.ordered.with(['-i', 'modify', 'user', 'where', 'name=foo', 'account=test', 'cluster=linux', 'partition=testpart', 'set', 'grptres=cpu=1'])
         resource.provider.grp_tres = { 'cpu' => 1 }
         resource.provider.flush
+      end
+      
+      context 'with coordinator role' do
+        it 'updates a user to add coordinator role' do
+          resource[:partition] = 'testpart'
+          expect(resource.provider).to receive(:sacctmgr).once.ordered.with(['-i', 'modify', 'user', 'where', 'name=foo', 'account=test', 'cluster=linux', 'partition=testpart', 'set', 'grptres=cpu=1'])
+          expect(resource.provider).to receive(:sacctmgr).once.ordered.with(['-i', 'add', 'coordinator', 'account=test', 'user=foo'])
+          resource.provider.grp_tres = { 'cpu' => 1 }
+          resource.provider.coordinator = :true
+          resource.provider.flush
+        end
+        
+        it 'updates a user to remove coordinator role' do
+          resource[:partition] = 'testpart'
+          resource[:coordinator] = :true
+          expect(resource.provider).to receive(:sacctmgr).once.ordered.with(['-i', 'modify', 'user', 'where', 'name=foo', 'account=test', 'cluster=linux', 'partition=testpart', 'set', 'grptres=cpu=1'])
+          expect(resource.provider).to receive(:sacctmgr).once.ordered.with(['-i', 'remove', 'coordinator', 'account=test', 'user=foo'])
+          resource.provider.grp_tres = { 'cpu' => 1 }
+          resource.provider.coordinator = :false
+          resource.provider.flush
+        end
       end
     end
   end

--- a/spec/unit/puppet/provider/slurm_user/sacctmgr_spec.rb
+++ b/spec/unit/puppet/provider/slurm_user/sacctmgr_spec.rb
@@ -114,7 +114,7 @@ describe Puppet::Type.type(:slurm_user).provider(:sacctmgr) do
       property_hash = described_class.instances[4].instance_variable_get('@property_hash')
       expect(property_hash[:coordinator]).to eq(:true)
     end
-    
+
     it 'creates instance with multiple coordinator roles' do
       allow(described_class).to receive(:sacctmgr) \
         .with(['list', 'user', "format=#{format_string}", '--noheader', '--parsable2', 'withassoc', 'withcoord']).and_return(my_fixture_read('list.out'))
@@ -157,7 +157,7 @@ describe Puppet::Type.type(:slurm_user).provider(:sacctmgr) do
         resource.provider.coordinator = :true
         resource.provider.flush
       end
-      
+
       it 'updates a user to remove coordinator role' do
         resource[:coordinator] = :true
         expect(resource.provider).to receive(:sacctmgr).once.ordered.with(['-i', 'modify', 'user', 'where', 'name=foo', 'account=test', 'cluster=linux', 'partition=', 'set', 'grptres=cpu=1'])
@@ -175,21 +175,29 @@ describe Puppet::Type.type(:slurm_user).provider(:sacctmgr) do
         resource.provider.grp_tres = { 'cpu' => 1 }
         resource.provider.flush
       end
-      
+
       context 'with coordinator role' do
         it 'updates a user to add coordinator role' do
           resource[:partition] = 'testpart'
-          expect(resource.provider).to receive(:sacctmgr).once.ordered.with(['-i', 'modify', 'user', 'where', 'name=foo', 'account=test', 'cluster=linux', 'partition=testpart', 'set', 'grptres=cpu=1'])
+          expect(resource.provider).to receive(:sacctmgr).once.ordered.with(
+            [
+              '-i', 'modify', 'user', 'where', 'name=foo', 'account=test', 'cluster=linux', 'partition=testpart', 'set', 'grptres=cpu=1',
+            ],
+          )
           expect(resource.provider).to receive(:sacctmgr).once.ordered.with(['-i', 'add', 'coordinator', 'account=test', 'user=foo'])
           resource.provider.grp_tres = { 'cpu' => 1 }
           resource.provider.coordinator = :true
           resource.provider.flush
         end
-        
+
         it 'updates a user to remove coordinator role' do
           resource[:partition] = 'testpart'
           resource[:coordinator] = :true
-          expect(resource.provider).to receive(:sacctmgr).once.ordered.with(['-i', 'modify', 'user', 'where', 'name=foo', 'account=test', 'cluster=linux', 'partition=testpart', 'set', 'grptres=cpu=1'])
+          expect(resource.provider).to receive(:sacctmgr).once.ordered.with(
+            [
+              '-i', 'modify', 'user', 'where', 'name=foo', 'account=test', 'cluster=linux', 'partition=testpart', 'set', 'grptres=cpu=1',
+            ],
+          )
           expect(resource.provider).to receive(:sacctmgr).once.ordered.with(['-i', 'remove', 'coordinator', 'account=test', 'user=foo'])
           resource.provider.grp_tres = { 'cpu' => 1 }
           resource.provider.coordinator = :false


### PR DESCRIPTION
**This stacks on top of PR #39 .** Commit [Support for managing Account Coordinator role via slurm_user](https://github.com/treydock/puppet-slurm_providers/commit/7c6ac368a27e7f5ebea25652592deab62c1887c2) should be reviewed in isolation

This change implements support for managing Slurm Account Coordinator role for users.

Example usage:

```puppet
slurm_user { 'foouser under testaccount on barcluster':
  user        => 'foouser',
  account     => 'testaccount',
  coordinator => true,
}
```

`coordinator` defaults to false. When enabled, `sacctmgr [add|remove] coordinator` command is used to modify the coordinator role for the given user/account combination when the catalog resource is changed.

`coordinator` may not be set when the optional `partition` namevar is set; a validation error will be raised.

As account coordinators are not listable entities, in their own right, but reported as an attribute of associations, I have opted to implement support on the existing `slurm_user` type rather than implement a new type. Since managing coordinators also requires separate `sacctmgr` commands, this is a little awkward given the inheritance used on existing `slurm_*` types. It is however functional, and tests are included. This code is being used to manage coordinators in a production environment.

I'm unable to get puppet-strings running (due to an outdated environment) without producing a massive unwanted diff in REFERENCE.md, so it has not been updated.